### PR TITLE
celery: addition of task to send email via Celery

### DIFF
--- a/invenio_mail/tasks.py
+++ b/invenio_mail/tasks.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Background tasks for mail module."""
+
+from __future__ import absolute_import, print_function
+
+from celery import shared_task
+from flask import current_app
+from flask_celeryext import RequestContextTask
+
+
+@shared_task(base=RequestContextTask)
+def send_email(msg):
+    """Celery task to send security email."""
+    current_app.extensions['mail'].send(msg)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ tests_require = [
 ]
 
 extras_require = {
+    'celery': [
+        'celery>=3.1.0',
+        'Flask-CeleryExt>=0.1.0',
+    ],
     'docs': [
         "Sphinx>=1.3",
     ],
@@ -123,6 +127,9 @@ setup(
         'invenio_base.apps': [
             'invenio_mail = invenio_mail:InvenioMail',
         ],
+        'invenio_celery.tasks': [
+            'invenio_mail = invenio_mail.tasks',
+        ]
     },
     extras_require=extras_require,
     install_requires=install_requires,

--- a/tests/test_invenio_mail_tasks.py
+++ b/tests/test_invenio_mail_tasks.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Module tests."""
+
+from __future__ import absolute_import, print_function
+
+from flask_mail import Message
+
+from invenio_mail.tasks import send_email
+
+
+def test_send_message_outbox(email_task_app):
+    """Test sending a message using Task module."""
+    with email_task_app.app_context():
+        with email_task_app.extensions['mail'].record_messages() as outbox:
+            msg = Message('Test1',
+                          sender='test1@test1.test1',
+                          recipients=['test1@test1.test1'])
+
+            send_email(msg)
+
+            assert len(outbox) == 1
+            sent_msg = outbox[0]
+            assert sent_msg.subject == 'Test1'
+            assert sent_msg.sender == 'test1@test1.test1'
+            assert sent_msg.recipients == ['test1@test1.test1']
+
+
+def test_send_message_stream(email_task_app):
+    """Test sending a message using Task module."""
+    with email_task_app.app_context():
+        with email_task_app.extensions['mail'].record_messages() as outbox:
+            msg = Message('Test2',
+                          sender='test2@test2.test2',
+                          recipients=['test2@test2.test2'])
+
+            send_email(msg)
+
+            result_stream = email_task_app.extensions['invenio-mail'].stream
+            assert result_stream.getvalue().find(
+                'From: test2@test2.test2') != -1
+            assert result_stream.getvalue().find('To: test2@test2.test2') != -1
+            assert result_stream.getvalue().find('Subject: Test2') != -1


### PR DESCRIPTION
* Added Task module and implemented a method
  which sends an email using Celery. (Closes #1)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>