### PR TITLE
docs: sphinx celery decorator fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,6 @@ env:
 python:
   - "2.7"
   - "3.5"
-  - "pypy"
-
-matrix:
-  allow_failures:
-    - python: pypy
 
 before_install:
   - "travis_retry pip install --upgrade pip setuptools py"

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,7 @@ Extension
 
 Tasks
 -----
-.. autotask:: invenio_mail.tasks.send_email
+.. autotask:: invenio_mail.tasks.send_email(data)
 
 Templated Messages
 ------------------


### PR DESCRIPTION
* Fixes sphinx error related to celery. Did not take the [scenic route](https://github.com/celery/vine/pull/19). For now adding the right signature in the .rst fixes the problem, as mentioned in https://stackoverflow.com/questions/3687046/python-sphinx-autodoc-and-decorated-members.

* Removes pypy from the travis matrix.

* Closes (https://github.com/inveniosoftware/invenio-mail/issues/38)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>