### PR TITLE
Default TemplatedMessage ctx to {}

### DIFF
--- a/invenio_mail/api.py
+++ b/invenio_mail/api.py
@@ -17,7 +17,7 @@ from flask_mail import Message
 class TemplatedMessage(Message):
     """Siplify creation of templated messages."""
 
-    def __init__(self, template_body=None, template_html=None, ctx=None,
+    def __init__(self, template_body=None, template_html=None, ctx={},
                  **kwargs):
         r"""Build message body and HTML based on provided templates.
 

--- a/invenio_mail/api.py
+++ b/invenio_mail/api.py
@@ -17,7 +17,7 @@ from flask_mail import Message
 class TemplatedMessage(Message):
     """Siplify creation of templated messages."""
 
-    def __init__(self, template_body=None, template_html=None, ctx={},
+    def __init__(self, template_body=None, template_html=None, ctx=None,
                  **kwargs):
         r"""Build message body and HTML based on provided templates.
 
@@ -31,6 +31,7 @@ class TemplatedMessage(Message):
         :param \*\*kwargs: Keyword arguments as defined in
             :class:`flask_mail.Message`.
         """
+        ctx = ctx if ctx else {}
         if template_body:
             kwargs['body'] = render_template(
                 template_body, body=kwargs.get('body'), **ctx

--- a/tests/test_invenio_mail_api.py
+++ b/tests/test_invenio_mail_api.py
@@ -30,3 +30,11 @@ def test_templated_message(email_api_app, email_params, email_ctx):
         assert '{0}'.format(email_ctx['content']) in msg.body
         assert email_ctx['sender'] in msg.html
         assert email_ctx['sender'] in msg.body
+
+
+def test_simple_templated_message(email_api_app):
+    """Test that defaults are sane."""
+    with email_api_app.app_context():
+        msg = TemplatedMessage(template_body='invenio_mail/base.txt',
+                               template_html='invenio_mail/base.html')
+        assert msg


### PR DESCRIPTION
Fixes an issue that would occur when no `ctx` was passed.

The `CONTRIBUTING.rst` file for this project was great, by the way!