### PR TITLE
tests: change default task serializer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def email_task_app(request):
         CELERY_RESULT_BACKEND='cache',
         CELERY_CACHE_BACKEND='memory',
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        CELERY_TASK_SERIALIZER='pickle',
         MAIL_SUPPRESS_SEND=True
     )
     FlaskCeleryExt(app)


### PR DESCRIPTION
* Celery 4 changes default task serializer from `pickle`
  to `json` and `test_send_message_with_attachments` which
  has a binary file as attachment fails as the attachment is
  not JSON serializable (closes #47).