### PR TITLE
docs: attachments and tasks incompatible

### DIFF
--- a/invenio_mail/tasks.py
+++ b/invenio_mail/tasks.py
@@ -21,9 +21,12 @@ def send_email(data):
 
     .. warning::
 
-       Due to an incompatibility between MessagePack serialization and Message,
-       support for attachments and dates is limited. Consult the tests for
-       details.
+       Attachments do not work with Celery tasks since
+       :class:`flask_mail.Attachment` is not serializable in ``JSON``
+       nor ``msgpack``. Note that a
+       `custom serializer <http://docs.celeryproject.org/en/latest/
+       userguide/calling.html#serializers>`__
+       can be created if attachments are really needed.
     """
     msg = Message()
     msg.__dict__.update(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,6 @@ def email_task_app(request):
         CELERY_RESULT_BACKEND='cache',
         CELERY_CACHE_BACKEND='memory',
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
-        CELERY_TASK_SERIALIZER='pickle',
         MAIL_SUPPRESS_SEND=True
     )
     FlaskCeleryExt(app)

--- a/tests/test_invenio_mail_tasks.py
+++ b/tests/test_invenio_mail_tasks.py
@@ -57,32 +57,6 @@ def test_send_message_stream(email_task_app):
             assert result_stream.getvalue().find('Subject: Test2') != -1
 
 
-def test_send_message_with_attachments(email_task_app):
-    """Test sending a message with attachments."""
-    with email_task_app.app_context():
-        filename = pkg_resources.resource_filename(
-            __name__, os.path.join('attachments', 'invenio.svg'))
-        content_type = 'image/svg+xml'
-        data = pkg_resources.resource_string(
-            __name__, os.path.join('attachments', 'invenio.svg'))
-
-        attachments = [Attachment(filename, content_type, data)]
-        msg = {
-            'subject': 'Test3',
-            'sender': 'test3@test3.test3',
-            'recipients': ['test3@test3.test3'],
-            'attachments': attachments
-        }
-
-        send_email.delay(msg)
-
-        result_stream = email_task_app.extensions['invenio-mail'].stream
-        assert result_stream.getvalue().find(
-            'Content-Transfer-Encoding: base64') != -1
-        assert result_stream.getvalue().find(
-            'Content-Disposition: attachment;') != -1
-
-
 def test_send_message_with_date(email_task_app):
     """Test sending a message with a date."""
     with email_task_app.app_context():


### PR DESCRIPTION
* Removes test for mails with attchment through Celery task
  since the only serialization compatible with Flask Mail
  Attachment is `pickle` an it should not be used as it is
  not safe.